### PR TITLE
Potential fix for code scanning alert no. 7: Disallow TypeScript namespaces

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -83,19 +83,16 @@ expect.extend({
 /**
  * Extend global Jest matcher types to include `toBeWithinRange`.
  */
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace jest {
-    interface Matchers<R> {
-      /**
-       * Asserts that a number is within a specified range (inclusive).
-       *
-       * @param floor - Minimum expected value.
-       * @param ceiling - Maximum expected value.
-       * @returns Custom matcher result.
-       */
-      toBeWithinRange(floor: number, ceiling: number): R;
-    }
+declare module 'jest' {
+  interface Matchers<R> {
+    /**
+     * Asserts that a number is within a specified range (inclusive).
+     *
+     * @param floor - Minimum expected value.
+     * @param ceiling - Maximum expected value.
+     * @returns Custom matcher result.
+     */
+    toBeWithinRange(floor: number, ceiling: number): R;
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dynamic-Innovative-Studio/friendly-dates/security/code-scanning/7](https://github.com/Dynamic-Innovative-Studio/friendly-dates/security/code-scanning/7)

To fix the issue, we will replace the `namespace jest` block with module augmentation. TypeScript allows us to augment existing modules by declaring the module and adding new types to it. In this case, we will declare the `jest` module and extend its `Matchers` interface to include the `toBeWithinRange` matcher. This approach avoids the use of namespaces and aligns with modern TypeScript practices.

Steps to fix:  
1. Replace the `namespace jest` block with a `declare module 'jest'` block.  
2. Move the `Matchers` interface into the module declaration.  
3. Ensure the functionality remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
